### PR TITLE
Update PolicyCVSSRange To and From properties to the correct type

### DIFF
--- a/xray/v1/policies.go
+++ b/xray/v1/policies.go
@@ -9,8 +9,8 @@ import (
 type PoliciesService Service
 
 type PolicyCVSSRange struct {
-	To   *string `json:"to,omitempty"`
-	From *string `json:"from,omitempty"`
+	To   *int `json:"to,omitempty"`
+	From *int `json:"from,omitempty"`
 }
 
 type PolicyRuleCriteria struct {


### PR DESCRIPTION
## What:
Updates the PolicyCVSSRange To and From properties to the correct type.

## Why:
To fixes unmarshal error.