### PR TITLE
Add RepoType to WatchProjectResource

### DIFF
--- a/xray/v2/watches.go
+++ b/xray/v2/watches.go
@@ -33,6 +33,7 @@ type WatchFilter struct {
 
 type WatchProjectResource struct {
 	Type            *string        `json:"type,omitempty"`
+	RepoType        *string        `json:"repo_type,omitempty"`
 	BinaryManagerId *string        `json:"bin_mgr_id,omitempty"`
 	Name            *string        `json:"name,omitempty"`
 	Filters         *[]WatchFilter `json:"filters,omitempty"`


### PR DESCRIPTION
The `repo_type` is included in xray watch responses and is required when adding remote repositories.

This is a required change to fix https://github.com/jfrog/terraform-provider-artifactory/issues/56